### PR TITLE
Fix `stargate#ok_vim` with a pattern which matches only 1 destination

### DIFF
--- a/_import/vim9000.vim
+++ b/_import/vim9000.vim
@@ -82,7 +82,12 @@ export def OkVIM(mode: any)
       destinations = sg.GetDestinations(mode)
     endif
     if !empty(destinations)
-      UseStargate(destinations)
+      if len(destinations) == 1
+        msg.BlankMessage()
+        cursor(destinations.jump.orbit, destinations.jump.degree)
+      else
+        UseStargate(destinations)
+      endif
     endif
   catch
     :echom v:exception
@@ -190,10 +195,6 @@ def ChooseDestinations(mode: number): dict<any>
     if empty(destinations)
       msg.Error("We can't reach there, " .. g:stargate_name .. '.')
       continue
-    elseif len(destinations) == 1
-      msg.BlankMessage()
-      cursor(destinations.jump.orbit, destinations.jump.degree)
-      return {}
     end
     break
   endwhile


### PR DESCRIPTION
Hi. Thank you for the great plugin! vim9-stargate makes my Vim life very confortable.

I found vim9-stargate's strange behavior. I think it may be a bug. This pull request fixes the behavior.


### Summary

When there is only 1 destination, `stargate#ok_vim` with a number argument immediately goes to the destination. But if a
pattern (string) argument is given, `stargate#ok_vim` doesn't work when there is only 1 destination. Patterns which
match multiple destinations are always OK.

### Steps to reproduce the behavior

1. [Shell] start Vim where vim9-stargate is available
2. [Vim] open vim9-stargate's `autoload/stargate.vim`
3. [Vim] execute `:call stargate#ok_vim('#g')`

Expected behavior is that the cursor moves to `#` in `def stargate#galaxy()` (line 57). But actual behavior is that no
destinations are displayed and the cursor doesn't move.

Best regards.