### PR TITLE
Fix `:end` to `:endif` in `_import/vim9000.vim`

### DIFF
--- a/_import/vim9000.vim
+++ b/_import/vim9000.vim
@@ -195,7 +195,7 @@ def ChooseDestinations(mode: number): dict<any>
     if empty(destinations)
       msg.Error("We can't reach there, " .. g:stargate_name .. '.')
       continue
-    end
+    endif
     break
   endwhile
 


### PR DESCRIPTION
Hi. I fixed `:end` to `:endif` because `:end` is not allowed and causes an error in recent Vim9 script.

cf. https://github.com/vim/vim/commit/204852ae2adfdde10c656ca7f14e5b4207a69172